### PR TITLE
Fixup Python 2/3 compat layer for nose

### DIFF
--- a/lz4framed/compat.py
+++ b/lz4framed/compat.py
@@ -55,5 +55,9 @@ if PY2:
 
 else:
     STDIN_RAW = stdin.buffer  # pylint: disable=no-member,redefined-variable-type
-    STDOUT_RAW = stdout.buffer  # pylint: disable=no-member,redefined-variable-type
+    try:
+        # This fix is required with nose that already captures the output.
+        STDOUT_RAW = stdout.buffer  # pylint: disable=no-member,redefined-variable-type
+    except AttributeError:
+        STDOUT_RAW = stdout
     STDERR_RAW = stderr.buffer  # pylint: disable=no-member,redefined-variable-type


### PR DESCRIPTION
nose is the unit-testing framework that I used to run your tests, however, nose captures stdout by default, which breaks the definition of `STDOUT_RAW` under Python 3.

This simple patch fixed the issue for me.
