### PR TITLE
Fix index in argv

### DIFF
--- a/lz4framed/__main__.py
+++ b/lz4framed/__main__.py
@@ -85,7 +85,7 @@ which case stdin is used. If OUTFILE is not specified, output goes to stdout."""
             out_stream = STDOUT_RAW
         else:
             try:
-                out_stream = out_file = open(argv[2], 'ab')
+                out_stream = out_file = open(argv[3], 'ab')
             except IOError as ex:
                 __error('Failed to open output file for appending: %s' % ex)
                 return 4


### PR DESCRIPTION
The output from the `__main__.py` executable was always appended to the input file, which is probably not correct.
